### PR TITLE
Add GitHub Skills activity to signup page

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills through GitHub's certification program",
+        "schedule": "Wednesdays, 3:30 PM - 4:30 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
This PR adds the missing GitHub Skills activity to the activities list, as requested in issue #6. The activity was announced by the principal but was not available for signup.

Changes:
- Added "GitHub Skills" activity with description, schedule, max participants, and empty participants list.

This addresses the urgent issue where students cannot sign up for the GitHub Skills activity before registrations close.